### PR TITLE
Update v2.go

### DIFF
--- a/vendor/github.com/mailhog/MailHog-Server/api/v2.go
+++ b/vendor/github.com/mailhog/MailHog-Server/api/v2.go
@@ -116,7 +116,7 @@ func (apiv2 *APIv2) messages(w http.ResponseWriter, req *http.Request) {
 	res.Total = apiv2.config.Storage.Count()
 
 	bytes, _ := json.Marshal(res)
-	w.Header().Add("Content-Type", "text/json")
+	w.Header().Add("Content-Type", "application/json")
 	w.Write(bytes)
 }
 


### PR DESCRIPTION
Use the right Media Type for JSON: "application/json" instead of "text/json" #165